### PR TITLE
Adapt checkstyle rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ Modifications of that ruleset are the following :
  * Methods annotated with `@Bean`, `@After`, `@Before` require no javadoc.
  * Constructors require no javadoc (subject to change)
  * Block indentation is using 4 spaces instead of 2
+ * Indentation for wrapped lines (continuation) is using 8 spaces
+ * whitespaceAround is disabled
+ * Javadoc allows paragraph tags on their own lines
  * Empty catch blocks are allowed
  * Sequential capital letters are allowed in names. (For example `codeISO3`)
  * Octal values and unicode escaped values are allowed (subject to change)
  * Members are allowed to be named : SMS
- * Line length limitations (120 characters) do not apply on lines which start with the `@PreAuthorize` annotation.
+ * Line length limitations (120 characters) do not apply on lines which start with the `@PreAuthorize` or `@ApiResponse` annotation.
  * Load errors in exception classes of javadoc blocks are suppressed

--- a/java-checkstyle.xml
+++ b/java-checkstyle.xml
@@ -32,7 +32,7 @@
         <module name="LineLength">
             <property name="max" value="120"/>
             <property name="ignorePattern"
-                      value="^package.*|^import.*|^\s+@PreAuthorize.*|a href|href|http://|https://|ftp://"/>
+                      value="^package.*|^import.*|^\s+@PreAuthorize.*|^\s+@ApiResponse.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
         <module name="OneTopLevelClass"/>

--- a/java-checkstyle.xml
+++ b/java-checkstyle.xml
@@ -57,16 +57,6 @@
                       value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT"/>
         </module>
-        <module name="WhitespaceAround">
-            <property name="allowEmptyConstructors" value="true"/>
-            <property name="allowEmptyMethods" value="true"/>
-            <property name="allowEmptyTypes" value="true"/>
-            <property name="allowEmptyLoops" value="true"/>
-            <message key="ws.notFollowed"
-                     value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
-            <message key="ws.notPreceded"
-                     value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
-        </module>
         <module name="OneStatementPerLine"/>
         <module name="MultipleVariableDeclarations"/>
         <module name="ArrayTypeStyle"/>
@@ -169,8 +159,8 @@
             <property name="basicOffset" value="4"/>
             <property name="braceAdjustment" value="0"/>
             <property name="caseIndent" value="4"/>
-            <property name="throwsIndent" value="4"/>
-            <property name="lineWrappingIndentation" value="4"/>
+            <property name="throwsIndent" value="8"/>
+            <property name="lineWrappingIndentation" value="8"/>
             <property name="arrayInitIndent" value="4"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
@@ -204,12 +194,10 @@
             <property name="allowSamelineMultipleAnnotations" value="true"/>
         </module>
         <module name="NonEmptyAtclauseDescription"/>
-        <module name="JavadocTagContinuationIndentation"/>
         <module name="SummaryJavadoc">
             <property name="forbiddenSummaryFragments"
                       value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
         </module>
-        <module name="JavadocParagraph"/>
         <module name="AtclauseOrder">
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
             <property name="target"


### PR DESCRIPTION
- Indent wrapped lines with 8 spaces instead of 4 in order to make method signatures more distinct from method bodies in case of throws declarations.
- Remove whitespaceAround rules in order to avoid having spaces before opening braces annotations with array values.
- Remove some javadoc formatting styles in order to make them slightly more lenient and e.g. allow paragraph tags on their own line.
- Exclude lines that start with @ApiResponse from checking for max line length.